### PR TITLE
Improve syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "elementary-theme" extension will be documented in th
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## 0.1.6
+- Better syntax highlighting
+
 ## 0.1.5
 - Better terminal colors
 - Fixed a couple legibility issues in peek view results

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "displayName": "Elementary theme",
     "description": "A theme that fits with elementary OS stylesheet",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "engines": {
         "vscode": "^1.52.0"
     },

--- a/themes/Elementary-light.json
+++ b/themes/Elementary-light.json
@@ -71,23 +71,25 @@
         // Scroll Bar
         "scrollbar.shadow": "#EBEBEB",
         // Tabs
-        "tab.border": "#ddd6c1",
+        "tab.border": "#e9d18d",
+        "tab.activeBorder": "#fdf6e3",
         "tab.activeBackground": "#fdf6e3",
         "tab.activeForeground": "#403f53",
         "tab.inactiveForeground": "#586e75",
-        "tab.inactiveBackground": "#d3cbb7",
+        "tab.inactiveBackground": "#fbefce",
         "editorGroup.border": "#ddd6c1",
         "editorGroup.emptyBackground": "#FDF6E5",
-        "editorGroupHeader.tabsBackground": "#d9d2c2",
-        "editorGroupHeader.tabsBorder": "#ddd6c1",
-        "editorGroupHeader.noTabsBackground": "#fffbf2",
+        "editorGroupHeader.border": "#e9d18d",
+        "editorGroupHeader.noTabsBackground": "#fbefce",
+        "editorGroupHeader.tabsBackground": "#fbefce",
+        "editorGroupHeader.tabsBorder": "#e9d18d",
         // Editor
         "editor.background": "#fdf6e3",
         "editor.foreground": "#403f53",
         "editorCursor.foreground": "#657b83",
         "editorLineNumber.foreground": "#9ca8a6",
         "editorLineNumber.activeForeground": "#6f7776",
-        "editor.selectionBackground": "#eee8d5",
+        "editor.selectionBackground": "#7e808777",
         "editor.selectionHighlightBackground": "#339cec33",
         "editor.wordHighlightBackground": "#339cec33",
         "editor.wordHighlightStrongBackground": "#007dd659",
@@ -187,821 +189,510 @@
 
         "welcomePage.buttonBackground": "#434c5e",
         "welcomePage.buttonHoverBackground": "#4c566a",
-        "walkThrough.embeddedEditorBackground": "#292c3d",
+        "walkThrough.embeddedEditorBackground": "#292c3d",        
     },
     "tokenColors": [
         {
-            "name": "Comment",
+            "settings": {
+                "foreground": "#333333ff",
+                "background": "#fdf6e3ff"
+            }
+        },
+        {
             "scope": [
-                "comment",
-                "punctuation.definition.comment"
+                "meta.embedded",
+                "source.groovy.embedded"
             ],
+            "settings": {
+                "background": "#FDF6E3",
+                "foreground": "#657B83"
+            }
+        },
+        {
+            "name": "Comment",
+            "scope": "comment",
             "settings": {
                 "fontStyle": "italic",
-                "foreground": "#9493a3"
+                "foreground": "#93A1A1"
             }
         },
         {
-            "name": "Variables",
-            "scope": [
-                "variable",
-                "string constant.other.placeholder"
-            ],
+            "name": "String",
+            "scope": "string",
             "settings": {
-                "foreground": "#657d97",
-                "fontStyle": "italic"
+                "foreground": "#2AA198"
             }
         },
         {
-            "name": "Colors",
+            "name": "Regexp",
+            "scope": "string.regexp",
+            "settings": {
+                "foreground": "#D30102"
+            }
+        },
+        {
+            "name": "Number",
+            "scope": "constant.numeric",
+            "settings": {
+                "foreground": "#D33682"
+            }
+        },
+        {
+            "name": "Variable",
             "scope": [
-                "constant.other.color"
+                "variable.language",
+                "variable.other"
             ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#268BD2"
             }
+        },
+        {
+            "name": "Keyword",
+            "scope": "keyword",
+            "settings": {
+                "foreground": "#859900"
+            }
+        },
+        {
+            "name": "Storage",
+            "scope": "storage",
+            "settings": {
+                "fontStyle": "bold",
+                "foreground": "#073642"
+            }
+        },
+        {
+            "name": "Class name",
+            "scope": [
+                "entity.name.class",
+                "entity.name.type"
+            ],
+            "settings": {
+                "foreground": "#268BD2"
+            }
+        },
+        {
+            "name": "Function name",
+            "scope": "entity.name.function",
+            "settings": {
+                "foreground": "#268BD2"
+            }
+        },
+        {
+            "name": "Variable start",
+            "scope": "punctuation.definition.variable",
+            "settings": {
+                "foreground": "#859900"
+            }
+        },
+        {
+            "name": "Embedded code markers",
+            "scope": [
+                "punctuation.section.embedded.begin",
+                "punctuation.section.embedded.end"
+            ],
+            "settings": {
+                "foreground": "#D30102"
+            }
+        },
+        {
+            "name": "Built-in constant",
+            "scope": [
+                "constant.language",
+                "meta.preprocessor"
+            ],
+            "settings": {
+                "foreground": "#B58900"
+            }
+        },
+        {
+            "name": "Support.construct",
+            "scope": [
+                "support.function.construct",
+                "keyword.other.new"
+            ],
+            "settings": {
+                "foreground": "#D30102"
+            }
+        },
+        {
+            "name": "User-defined constant",
+            "scope": [
+                "constant.character",
+                "constant.other"
+            ],
+            "settings": {
+                "foreground": "#CB4B16"
+            }
+        },
+        {
+            "name": "Inherited class",
+            "scope": "entity.other.inherited-class",
+            "settings": {}
+        },
+        {
+            "name": "Function argument",
+            "scope": "variable.parameter",
+            "settings": {}
+        },
+        {
+            "name": "Tag name",
+            "scope": "entity.name.tag",
+            "settings": {
+                "foreground": "#268BD2"
+            }
+        },
+        {
+            "name": "Tag start/end",
+            "scope": [
+                "punctuation.definition.tag.begin",
+                "punctuation.definition.tag.end"
+            ],
+            "settings": {
+                "foreground": "#93A1A1"
+            }
+        },
+        {
+            "name": "Tag attribute",
+            "scope": "entity.other.attribute-name",
+            "settings": {
+                "foreground": "#93A1A1"
+            }
+        },
+        {
+            "name": "Library function",
+            "scope": "support.function",
+            "settings": {
+                "foreground": "#268BD2"
+            }
+        },
+        {
+            "name": "Continuation",
+            "scope": "punctuation.separator.continuation",
+            "settings": {
+                "foreground": "#D30102"
+            }
+        },
+        {
+            "name": "Library constant",
+            "scope": "support.constant",
+            "settings": {}
+        },
+        {
+            "name": "Library class/type",
+            "scope": [
+                "support.type",
+                "support.class"
+            ],
+            "settings": {
+                "foreground": "#859900"
+            }
+        },
+        {
+            "name": "Library Exception",
+            "scope": "support.type.exception",
+            "settings": {
+                "foreground": "#CB4B16"
+            }
+        },
+        {
+            "name": "Library variable",
+            "scope": "support.other.variable",
+            "settings": {}
         },
         {
             "name": "Invalid",
-            "scope": [
-                "invalid",
-                "invalid.illegal"
-            ],
-            "settings": {
-                "foreground": "#ad5f00"
-            }
+            "scope": "invalid",
+            "settings": {}
         },
         {
-            "name": "Keyword, Storage",
+            "name": "diff: header",
             "scope": [
-                "keyword",
-                "storage.type",
-                "storage.modifier"
+                "meta.diff",
+                "meta.diff.header"
             ],
             "settings": {
-                "foreground": "#a56de2"
-            }
-        },
-        {
-            "name": "Operator, Misc",
-            "scope": [
-                "keyword.control",
-                "constant.other.color",
-                "punctuation",
-                "meta.tag",
-                "punctuation.definition.tag",
-                "punctuation.separator.inheritance.php",
-                "punctuation.definition.tag.html",
-                "punctuation.definition.tag.begin.html",
-                "punctuation.definition.tag.end.html",
-                "punctuation.section.embedded",
-                "keyword.other.template",
-                "keyword.other.substitution"
-            ],
-            "settings": {
-                "foreground": "#0e9a83"
-            }
-        },
-        {
-            "name": "Tag",
-            "scope": [
-                "entity.name.tag",
-                "meta.tag.sgml",
-                "markup.deleted.git_gutter"
-            ],
-            "settings": {
-                "foreground": "#f4679d"
-            }
-        },
-        {
-            "name": "Variable Property Other object property",
-            "scope": [
-                "variable.other.object.property"
-            ],
-            "settings": {
-                "foreground": "#faf39f",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "Function, Special Method",
-            "scope": [
-                "entity.name.function",
-                "meta.function-call",
-                "variable.function",
-                "support.function",
-                "keyword.other.special-method"
-            ],
-            "settings": {
-                "foreground": "#a56de2"
-            }
-        },
-        {
-            "name": "Block Level Variables",
-            "scope": [
-                "meta.block variable.other"
-            ],
-            "settings": {
-                "foreground": "#f7c1a7"
-            }
-        },
-        {
-            "name": "Other Variable, String Link",
-            "scope": [
-                "support.other.variable",
-                "string.other.link"
-            ],
-            "settings": {
-                "foreground": "#f7c1a7"
-            }
-        },
-        {
-            "name": "Number, Constant, Function Argument, Tag Attribute, Embedded",
-            "scope": [
-                "constant.numeric",
-                "constant.language",
-                "support.constant",
-                "constant.character",
-                "constant.escape",
-                "variable.parameter",
-                "keyword.other.unit",
-                "keyword.other"
-            ],
-            "settings": {
-                "foreground": "#ad5f00",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "String, Symbols, Markup Heading",
-            "scope": [
-                "string",
-                "markup.heading",
-                "markup.inserted.git_gutter"
-            ],
-            "settings": {
-                "foreground": "#8ec3f9"
-            }
-        },
-        {
-            "name": "String Quoted",
-            "scope": [
-                "string.quoted",
-                "variable.other.readwrite.js",
-                "string.quoted.single.js"
-            ],
-            "settings": {
-                "foreground": "#a56de2"
-            }
-        },
-        {
-            "name": "Object Keys",
-            "scope": [
-                "string.unquoted.js",
-                "constant.other.object.key.js",
-                "constant.other.symbol",
-                "constant.other.key",
-                "source.js"
-            ],
-            "settings": {
-                "foreground": "#0e9a83"
-            }
-        },
-        {
-            "name": "Inherited Class",
-            "scope": [
-                "entity.other.inherited-class",
-                "meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js"
-            ],
-            "settings": {
-                "foreground": "#657d97"
-            }
-        },
-        {
-            "name": "Class, Support",
-            "scope": [
-                "entity.name",
-                "support.type",
-                "support.class",
-                "support.orther.namespace.use.php",
-                "meta.use.php",
-                "support.other.namespace.php",
-                "markup.changed.git_gutter",
-                "support.type.sys-types"
-            ],
-            "settings": {
-                "foreground": "#657d97"
-            }
-        },
-        {
-            "name": "Entity Types",
-            "scope": [
-                "support.type"
-            ],
-            "settings": {
-                "foreground": "#B2CCD6"
-            }
-        },
-        {
-            "name": "CSS Class and Support",
-            "scope": [
-                "source.css support.type.property-name",
-                "source.sass support.type.property-name",
-                "source.scss support.type.property-name",
-                "source.less support.type.property-name",
-                "source.stylus support.type.property-name",
-                "source.postcss support.type.property-name"
-            ],
-            "settings": {
-                "foreground": "#b2f9e9"
-            }
-        },
-        {
-            "name": "Sub-methods",
-            "scope": [
-                "entity.name.module.js",
-                "variable.import.parameter.js",
-                "variable.other.class.js"
-            ],
-            "settings": {
-                "foreground": "#ad5f00"
-            }
-        },
-        {
-            "name": "Language methods",
-            "scope": [
-                "variable.language"
-            ],
-            "settings": {
+                "background": "#b58900",
                 "fontStyle": "italic",
-                "foreground": "#ad5f00"
+                "foreground": "#E0EDDD"
             }
         },
         {
-            "name": "entity.name.method.js",
-            "scope": [
-                "entity.name.method.js"
-            ],
+            "name": "diff: deleted",
+            "scope": "markup.deleted",
             "settings": {
-                "fontStyle": "italic",
-                "foreground": "#0e9a83"
+                "background": "#eee8d5",
+                "fontStyle": "",
+                "foreground": "#dc322f"
             }
         },
         {
-            "name": "meta.method.js",
-            "scope": [
-                "meta.class-method.js entity.name.function.js",
-                "variable.function.constructor"
-            ],
+            "name": "diff: changed",
+            "scope": "markup.changed",
             "settings": {
-                "foreground": "#a56de2"
+                "background": "#eee8d5",
+                "fontStyle": "",
+                "foreground": "#cb4b16"
             }
         },
         {
-            "name": "Attributes",
-            "scope": [
-                "entity.other.attribute-name"
-            ],
+            "name": "diff: inserted",
+            "scope": "markup.inserted",
             "settings": {
-                "foreground": "#6f895b"
+                "background": "#eee8d5",
+                "foreground": "#219186"
             }
         },
         {
-            "name": "HTML Attributes",
-            "scope": [
-                "text.html.basic entity.other.attribute-name.html",
-                "text.html.basic entity.other.attribute-name"
-            ],
+            "name": "Markup Quote",
+            "scope": "markup.quote",
             "settings": {
-                "fontStyle": "italic",
-                "foreground": "#bde5f5"
+                "foreground": "#859900"
             }
         },
         {
-            "name": "CSS Classes",
-            "scope": [
-                "entity.other.attribute-name.class"
-            ],
+            "name": "Markup Lists",
+            "scope": "markup.list",
             "settings": {
-                "foreground": "#a56de2"
+                "foreground": "#B58900"
             }
         },
         {
-            "name": "CSS ID's",
+            "name": "Markup Styling",
             "scope": [
-                "source.sass keyword.control"
-            ],
-            "settings": {
-                "foreground": "#a56de2"
-            }
-        },
-        {
-            "name": "Inserted",
-            "scope": [
-                "markup.inserted"
-            ],
-            "settings": {
-                "foreground": "#C3E88D"
-            }
-        },
-        {
-            "name": "Deleted",
-            "scope": [
-                "markup.deleted"
-            ],
-            "settings": {
-                "foreground": "#ad5f00"
-            }
-        },
-        {
-            "name": "Changed",
-            "scope": [
-                "markup.changed"
-            ],
-            "settings": {
-                "foreground": "#a56de2"
-            }
-        },
-        {
-            "name": "Regular Expressions",
-            "scope": [
-                "string.regexp"
-            ],
-            "settings": {
-                "fontStyle": "italic",
-                "foreground": "#0e9a83"
-            }
-        },
-        {
-            "name": "Escape Characters",
-            "scope": [
-                "constant.character.escape"
-            ],
-            "settings": {
-                "foreground": "#0e9a83"
-            }
-        },
-        {
-            "name": "URL",
-            "scope": [
-                "*url*",
-                "*link*",
-                "*uri*"
-            ],
-            "settings": {
-                "fontStyle": "underline"
-            }
-        },
-        {
-            "name": "Decorators",
-            "scope": [
-                "tag.decorator.js entity.name.tag.js",
-                "tag.decorator.js punctuation.definition.tag.js"
-            ],
-            "settings": {
-                "fontStyle": "italic",
-                "foreground": "#0e9a83"
-            }
-        },
-        {
-            "name": "ES7 Bind Operator",
-            "scope": [
-                "source.js constant.other.object.key.js string.unquoted.label.js"
-            ],
-            "settings": {
-                "fontStyle": "italic",
-                "foreground": "#ad5f00"
-            }
-        },
-        {
-            "name": "JSON Key - Level 0",
-            "scope": [
-                "source.json meta.structure.dictionary.json support.type.property-name.json"
-            ],
-            "settings": {
-                "foreground": "#0e9a83"
-            }
-        },
-        {
-            "name": "JSON Key - Level 1",
-            "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-            ],
-            "settings": {
-                "foreground": "#f4679d"
-            }
-        },
-        {
-            "name": "JSON Key - Level 2",
-            "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-            ],
-            "settings": {
-                "foreground": "#f4679d"
-            }
-        },
-        {
-            "name": "JSON Key - Level 3",
-            "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-            ],
-            "settings": {
-                "foreground": "#6f895b"
-            }
-        },
-        {
-            "name": "JSON Key - Level 4",
-            "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-            ],
-            "settings": {
-                "foreground": "#f4679d"
-            }
-        },
-        {
-            "name": "JSON Key - Level 5",
-            "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-            ],
-            "settings": {
-                "foreground": "#657d97"
-            }
-        },
-        {
-            "name": "JSON Key - Level 6",
-            "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-            ],
-            "settings": {
-                "foreground": "#f4679d"
-            }
-        },
-        {
-            "name": "JSON Key - Level 7",
-            "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-            ],
-            "settings": {
-                "foreground": "#a56de2"
-            }
-        },
-        {
-            "name": "JSON Key - Level 8",
-            "scope": [
-                "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-            ],
-            "settings": {
-                "foreground": "#C3E88D"
-            }
-        },
-        {
-            "name": "Markdown - Plain",
-            "scope": [
-                "text.html.markdown",
-                "punctuation.definition.list_item.markdown"
-            ],
-            "settings": {
-                "foreground": "#65737E"
-            }
-        },
-        {
-            "name": "Markdown - Markup Raw Inline",
-            "scope": [
-                "text.html.markdown markup.inline.raw.markdown"
-            ],
-            "settings": {
-                "foreground": "#a56de2"
-            }
-        },
-        {
-            "name": "Markdown - Markup Raw Inline Punctuation",
-            "scope": [
-                "text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown"
-            ],
-            "settings": {
-                "foreground": "#65737E"
-            }
-        },
-        {
-            "name": "Markdown - Heading",
-            "scope": [
-                "markdown.heading",
-                "markup.heading | markup.heading entity.name",
-                "markup.heading.markdown punctuation.definition.heading.markdown"
-            ],
-            "settings": {
-                "foreground": "#657d97"
-            }
-        },
-        {
-            "name": "Markup - Italic",
-            "scope": [
+                "markup.bold",
                 "markup.italic"
             ],
             "settings": {
-                "fontStyle": "italic",
-                "foreground": "#ad5f00"
+                "foreground": "#D33682"
             }
         },
         {
-            "name": "Markup - Bold",
-            "scope": [
-                "markup.bold",
-                "markup.bold string"
-            ],
+            "name": "Markup Inline",
+            "scope": "markup.inline.raw",
             "settings": {
-                "fontStyle": "bold",
-                "foreground": "#ad5f00"
+                "fontStyle": "",
+                "foreground": "#2AA198"
             }
         },
         {
-            "name": "Markup - Bold-Italic",
-            "scope": [
-                "markup.bold markup.italic",
-                "markup.italic markup.bold",
-                "markup.quote markup.bold",
-                "markup.bold markup.italic string",
-                "markup.italic markup.bold string",
-                "markup.quote markup.bold string"
-            ],
+            "name": "Markup Headings",
+            "scope": "markup.heading",
             "settings": {
-                "fontStyle": "bold",
-                "foreground": "#ad5f00"
+                "foreground": "#268BD2"
             }
         },
         {
-            "name": "Markup - Underline",
-            "scope": [
-                "markup.underline"
-            ],
+            "name": "Markup Setext Header",
+            "scope": "markup.heading.setext",
             "settings": {
-                "fontStyle": "underline",
-                "foreground": "#ad5f00"
+                "fontStyle": "",
+                "foreground": "#268BD2"
             }
         },
         {
-            "name": "Markdown - Blockquote",
-            "scope": [
-                "markup.quote punctuation.definition.blockquote.markdown"
-            ],
+            "scope": "token.info-token",
             "settings": {
-                "foreground": "#65737E"
+                "foreground": "#316bcd"
             }
         },
         {
-            "name": "Markup - Quote",
-            "scope": [
-                "markup.quote"
-            ],
+            "scope": "token.warn-token",
             "settings": {
-                "fontStyle": "italic"
+                "foreground": "#cd9731"
             }
         },
         {
-            "name": "Markdown - Link",
-            "scope": [
-                "string.other.link.title.markdown"
-            ],
+            "scope": "token.error-token",
             "settings": {
-                "foreground": "#a56de2"
+                "foreground": "#cd3131"
             }
         },
         {
-            "name": "Markdown - Link Description",
-            "scope": [
-                "string.other.link.description.title.markdown"
-            ],
+            "scope": "token.debug-token",
             "settings": {
-                "foreground": "#a56de2"
+                "foreground": "#800080"
             }
         },
         {
-            "name": "Markdown - Link Anchor",
-            "scope": [
-                "constant.other.reference.link.markdown"
-            ],
+            "scope": "storage.modifier",
             "settings": {
-                "foreground": "#bde5f5"
-            }
-        },
-        {
-            "name": "Markup - Raw Block",
-            "scope": [
-                "markup.raw.block"
-            ],
-            "settings": {
-                "foreground": "#a56de2"
-            }
-        },
-        {
-            "name": "Markdown - Raw Block Fenced",
-            "scope": [
-                "markup.raw.block.fenced.markdown"
-            ],
-            "settings": {
-                "foreground": "#00000050"
-            }
-        },
-        {
-            "name": "Markdown - Fenced Bode Block",
-            "scope": [
-                "punctuation.definition.fenced.markdown"
-            ],
-            "settings": {
-                "foreground": "#00000050"
-            }
-        },
-        {
-            "name": "Markdown - Fenced Bode Block Variable",
-            "scope": [
-                "markup.raw.block.fenced.markdown",
-                "variable.language.fenced.markdown",
-                "punctuation.section.class.end"
-            ],
-            "settings": {
-                "foreground": "#EEFFFF"
-            }
-        },
-        {
-            "name": "Markdown - Fenced Language",
-            "scope": [
-                "variable.language.fenced.markdown"
-            ],
-            "settings": {
-                "foreground": "#65737E"
-            }
-        },
-        {
-            "name": "Markdown Inline Raw String",
-            "scope": "markup.inline.raw.string.markdown",
-            "settings": {
-                "foreground": "#f4679d"
-            }
-        },
-        {
-            "name": "Markdown - Separator",
-            "scope": [
-                "meta.separator"
-            ],
-            "settings": {
-                "fontStyle": "bold",
-                "foreground": "#65737E"
-            }
-        },
-        {
-            "name": "Markup - Table",
-            "scope": [
-                "markup.table"
-            ],
-            "settings": {
-                "foreground": "#EEFFFF"
-            }
-        },
-        {
-            "name": "TypeScript[React] Variables and Object Properties",
-            "scope": [
-                "variable.other.readwrite.alias.ts",
-                "variable.other.readwrite.alias.tsx",
-                "variable.other.readwrite.ts",
-                "variable.other.readwrite.tsx",
-                "variable.other.object.ts",
-                "variable.other.object.tsx",
-                "variable.object.property.ts",
-                "variable.object.property.tsx",
-                "variable.other.ts",
-                "variable.other.tsx",
-                "variable.tsx",
-                "variable.ts"
-            ],
-            "settings": {
-                "foreground": "#657d97"
-            }
-        },
-        {
-            "name": "YAML Entity Name Tags",
-            "scope": "entity.name.tag.yaml",
-            "settings": {
-                "foreground": "#657d97"
-            }
-        },
-        {
-            "name": "Go Constants e.g. nil, string format (%s, %d, etc.)",
-            "scope": [
-                "source.go constant.language.go",
-                "source.go constant.other.placeholder.go"
-            ],
-            "settings": {
-                "foreground": "#6f895b"
-            }
-        },
-        {
-            "name": "C++ Functions",
-            "scope": [
-                "entity.name.function.preprocessor.cpp",
-                "entity.scope.name.cpp"
-            ],
-            "settings": {
-                "foreground": "#6f895b"
-            }
-        },
-        {
-            "name": "C++ Meta Namespace",
-            "scope": [
-                "meta.namespace-block.cpp"
-            ],
-            "settings": {
-                "foreground": "#65737E"
-            }
-        },
-        {
-            "name": "C++ Language Primitive Storage",
-            "scope": [
-                "storage.type.language.primitive.cpp"
-            ],
-            "settings": {
-                "foreground": "#ff5874"
-            }
-        },
-        {
-            "name": "C++ Preprocessor Macro",
-            "scope": [
-                "meta.preprocessor.macro.cpp"
-            ],
-            "settings": {
-                "foreground": "#45cccc"
-            }
-        },
-        {
-            "name": "C++ Variable Parameter",
-            "scope": [
-                "variable.parameter"
-            ],
-            "settings": {
-                "foreground": "#6f895b"
-            }
-        },
-        {
-            "name": "Dart String",
-            "scope": [
-                "string.interpolated.single.dart",
-                "string.interpolated.double.dart"
-            ],
-            "settings": {
-                "foreground": "#ff5874"
-            }
-        },
-        {
-            "name": "Dart Class",
-            "scope": "support.class.dart",
-            "settings": {
-                "foreground": "#45cccc"
-            }
-        },
-        {
-            "name": "Ruby Variables",
-            "scope": [
-                "variable.other.ruby"
-            ],
-            "settings": {
-                "foreground": "#a56de2",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "scope": [
-                "variable.language.self.rust",
-                "keyword.other.rust"
-            ],
-            "settings": {
-                "foreground": "#ad5f00",
-                "fontStyle": "italic"
-            }
-        },
-        {
-            "name": "normalize font style of certain components",
-            "scope": [
-                "meta.property-list.css meta.property-value.css variable.other.less",
-                "meta.property-list.scss variable.scss",
-                "meta.property-list.sass variable.sass",
-                "meta.brace",
-                "keyword.operator.operator",
-                "keyword.operator.or.regexp",
-                "keyword.operator.expression.in",
-                "keyword.operator.relational",
-                "keyword.operator.assignment",
-                "keyword.operator.comparison",
-                "keyword.operator.type",
-                "keyword.operator",
-                "keyword",
-                "punctuation.definintion.string",
-                "punctuation",
-                "variable.other.readwrite.js",
-                "storage.type",
-                "source.css",
-                "string.quoted"
-            ],
-            "settings": {
+                "foreground": "#859900ff",
                 "fontStyle": ""
+            }
+        },
+        {
+            "scope": "storage.type",
+            "settings": {
+                "foreground": "#859900ff",
+                "fontStyle": ""
+            }
+        },
+        {
+            "scope": "keyword.control.import",
+            "settings": {
+                "foreground": "#D33682"
+            }
+        },
+        {
+            "scope": "storage.modifier.async",
+            "settings": {
+                "foreground": "#859900ff",
+                "fontStyle": ""
+            }
+        },
+        {
+            "scope": "meta.import",
+            "settings": {
+                "foreground": "#657b83"
+            }
+        },
+        {
+            "scope": "source.ts",
+            "settings": {
+                "foreground": "#657b83"
+            }
+        },
+        {
+            "scope": "meta.function-call",
+            "settings": {
+                "foreground": "#657b83"
+            }
+        },
+        {
+            "scope": "entity.name.type",
+            "settings": {
+                "foreground": "#b58900"
+            }
+        },
+        {
+            "scope": "entity.name.function",
+            "settings": {
+                "foreground": "#657b83"
+            }
+        },
+        {
+            "scope": "variable.other",
+            "settings": {
+                "foreground": "#657b83"
+            }
+        },
+        {
+            "scope": "storage.modifier.tsx",
+            "settings": {
+                "foreground": "#859900"
+            }
+        },
+        {
+            "scope": "storage.modifier",
+            "settings": {
+                "foreground": "#859900ff",
+                "fontStyle": ""
+            }
+        },
+        {
+            "scope": "storage.type",
+            "settings": {
+                "foreground": "#859900ff",
+                "fontStyle": ""
+            }
+        },
+        {
+            "scope": "keyword.control.import",
+            "settings": {
+                "foreground": "#D33682"
+            }
+        },
+        {
+            "scope": "storage.modifier.async",
+            "settings": {
+                "foreground": "#859900ff",
+                "fontStyle": ""
+            }
+        },
+        {
+            "scope": "meta.import",
+            "settings": {
+                "foreground": "#657b83"
+            }
+        },
+        {
+            "scope": "source.ts",
+            "settings": {
+                "foreground": "#657b83"
+            }
+        },
+        {
+            "scope": "meta.function-call",
+            "settings": {
+                "foreground": "#657b83"
+            }
+        },
+        {
+            "scope": "entity.name.type",
+            "settings": {
+                "foreground": "#b58900"
+            }
+        },
+        {
+            "scope": "entity.name.function",
+            "settings": {
+                "foreground": "#657b83"
+            }
+        },
+        {
+            "scope": "variable.other",
+            "settings": {
+                "foreground": "#657b83"
+            }
+        },
+        {
+            "scope": "storage.modifier.tsx",
+            "settings": {
+                "foreground": "#859900"
+            }
+        },
+        {
+            "scope": "punctuation.separator.dictionary.key-value.json, punctuation.separator.array.json, punctuation.separator.dictionary.pair.json",
+            "settings": {
+                "foreground": "#657B83"
+            }
+        },
+        {
+            "scope": "storage.type",
+            "settings": {
+                "foreground": "#268BD2"
+            }
+        },
+        {
+            "scope": "punctuation.definition.dictionary.begin.json, punctuation.definition.dictionary.end.json, punctuation.definition.array.begin.json, punctuation.definition.array.end.json",
+            "settings": {
+                "foreground": "#DC3272"
+            }
+        },
+        {
+            "scope": "support.type.primitive",
+            "settings": {
+                "foreground": "#b58900"
+            }
+        },
+        {
+            "scope": "keyword.control.import",
+            "settings": {
+                "foreground": "#cb4b16"
+            }
+        },
+        {
+            "scope": "keyword.control.from",
+            "settings": {
+                "foreground": "#cb4b16"
+            }
+        },
+        {
+            "scope": "source",
+            "settings": {
+                "foreground": "#657b83"
             }
         }
     ]

--- a/themes/Elementary-light.json
+++ b/themes/Elementary-light.json
@@ -186,6 +186,10 @@
         "titleBar.activeBackground": "#d6d6d6",
         "titleBar.inactiveBackground": "#d6d6d6",
         "titleBar.inactiveForeground": "#777777",
+        
+        // Inlay hints
+        "editorInlayHint.background": "#667885aa",
+        "editorInlayHint.foreground": "#fafafadd",
 
         "welcomePage.buttonBackground": "#434c5e",
         "welcomePage.buttonHoverBackground": "#4c566a",


### PR DESCRIPTION
I really like your theme and I think it looks great! But the syntax highlighting for most languages looked really weird. I noticed there was [another elementary theme](https://github.com/electricduck/vscode-elementary-theme) on the marketplace. That one does have nice syntax colors, but the editor theme doesn't fit in Odin, it's made for Juno. So I took their syntax colors and applied them to your theme. It should be okay, because it is MIT licensed.

Let me know what you think!